### PR TITLE
Add AI centralization risk video to press mentions

### DIFF
--- a/docusaurus/about/publications/press.md
+++ b/docusaurus/about/publications/press.md
@@ -19,7 +19,7 @@ description: "Mentions in the press/media"
 
 ## Impact and Public Goods Funding
 
-- ["Is AI the most dangerous centralization risk in crypto?" | Octant livestream 2026](https://www.youtube.com/watch?v=ZLdQ65RDrl0)
+- [Is AI the most dangerous centralization risk in crypto? | Octant livestream 2026](https://www.youtube.com/watch?v=ZLdQ65RDrl0)
 - [Funding Mechanisms Beyond One Model | Funding the Commons SF 2026](https://youtu.be/Fu0Vd_sauZs?si=hc7sVpAMgW2XZ2gh&t=2175)
 - [The Future of Public Goods Funding Panel | Funding the Commons Buenos Aires 2025](https://youtu.be/DmHQ2E8a9Fs?si=N9mnurVcfpFcDSgx)
 - [Open Source Observer - KYB #5 with Raymond Cheng & Carl Cervone | L2BEAT Podcast 2025](https://www.youtube.com/watch?v=Ji5v3_urn0Y)

--- a/docusaurus/about/publications/press.md
+++ b/docusaurus/about/publications/press.md
@@ -19,6 +19,7 @@ description: "Mentions in the press/media"
 
 ## Impact and Public Goods Funding
 
+- ["Is AI the most dangerous centralization risk in crypto?"](https://www.youtube.com/watch?v=ZLdQ65RDrl0)
 - [Funding Mechanisms Beyond One Model | Funding the Commons SF 2026](https://youtu.be/Fu0Vd_sauZs?si=hc7sVpAMgW2XZ2gh&t=2175)
 - [The Future of Public Goods Funding Panel | Funding the Commons Buenos Aires 2025](https://youtu.be/DmHQ2E8a9Fs?si=N9mnurVcfpFcDSgx)
 - [Open Source Observer - KYB #5 with Raymond Cheng & Carl Cervone | L2BEAT Podcast 2025](https://www.youtube.com/watch?v=Ji5v3_urn0Y)

--- a/docusaurus/about/publications/press.md
+++ b/docusaurus/about/publications/press.md
@@ -19,7 +19,7 @@ description: "Mentions in the press/media"
 
 ## Impact and Public Goods Funding
 
-- ["Is AI the most dangerous centralization risk in crypto?"](https://www.youtube.com/watch?v=ZLdQ65RDrl0)
+- ["Is AI the most dangerous centralization risk in crypto?" | Octant livestream 2026](https://www.youtube.com/watch?v=ZLdQ65RDrl0)
 - [Funding Mechanisms Beyond One Model | Funding the Commons SF 2026](https://youtu.be/Fu0Vd_sauZs?si=hc7sVpAMgW2XZ2gh&t=2175)
 - [The Future of Public Goods Funding Panel | Funding the Commons Buenos Aires 2025](https://youtu.be/DmHQ2E8a9Fs?si=N9mnurVcfpFcDSgx)
 - [Open Source Observer - KYB #5 with Raymond Cheng & Carl Cervone | L2BEAT Podcast 2025](https://www.youtube.com/watch?v=Ji5v3_urn0Y)


### PR DESCRIPTION
## Summary
Added a new press mention to the publications page documenting media coverage of the project.

## Changes
- Added YouTube video link: "Is AI the most dangerous centralization risk in crypto?" to the Impact and Public Goods Funding section of the press page
- The new entry is positioned at the top of the section's list

## Details
This update adds a recent media appearance to the press/media mentions documentation, expanding the public record of the project's coverage in discussions around AI, cryptocurrency, and centralization risks.

https://claude.ai/code/session_01R9gshjuXT2AbLshpwPQeo8